### PR TITLE
v1.7.0

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,15 @@
-﻿Aug 29, 2019: v1.5.0
+﻿Jan 24, 2021: v1.7.0
+	Released at https://www.nuget.org/packages/TypeClassMapper/1.7.0
+	Added net5.0 to existing test case runtimes (besides netcoreapp3.1).
+	AddMapping method adds exception for the case of unsupported non-deterministic object mapping.
+	Added ctor for Type_Class_Catalog with Client_Type type parameter is Type.
+
+Jan 24, 2021: v1.6.0
+	Released at https://www.nuget.org/packages/TypeClassMapper/1.6.0
+	Added net5.0 to existing test case runtimes (besides netcoreapp3.1).
+	AddMapping method adds exception for the case of unsupported non-deterministic object mapping.
+
+Aug 29, 2019: v1.5.0
 	Released at https://www.nuget.org/packages/TypeClassMapper/1.5.0
 	As .NET Standard
 

--- a/TargetingNETStandard2.sln
+++ b/TargetingNETStandard2.sln
@@ -23,7 +23,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".NET Core Runtime", ".NET C
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".NET Framework Runtime", ".NET Framework Runtime", "{D0D60C62-7F04-4C6D-BDE8-699B00C51BBB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "app1", "source\NETCoreRuntime\app1\app1.csproj", "{C6013FF7-CE44-40AE-AC0B-4225446A7B4E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "app1", "source\NETCoreRuntime\app1\app1.csproj", "{C6013FF7-CE44-40AE-AC0B-4225446A7B4E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9023D905-6525-4C07-A047-97B063B6094A}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+		nuget_release.xml = nuget_release.xml
+		README.md = README.md
+		ReleaseNotes.txt = ReleaseNotes.txt
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/nuget_release.xml
+++ b/nuget_release.xml
@@ -19,6 +19,8 @@ https://www.nuget.org/packages/upload
 \Users\Marco\Documents\tools\nuget delete TypeClassMapper 1.0.0 31ab53ce-94a1-49e8-9a41-f837cfc04f31 -s https://www.nuget.org/api/v2/package
 )
 published at:
+  https://www.nuget.org/packages/TypeClassMapper/1.7.0 (uploaded directly from auto-generated Cross-platform\TypeClassMapper\bin\Release\TypeClassMapper.1.7.0.nupkg)
+  https://www.nuget.org/packages/TypeClassMapper/1.6.0 (uploaded directly from auto-generated Cross-platform\TypeClassMapper\bin\Release\TypeClassMapper.1.6.0.nupkg)
   https://www.nuget.org/packages/TypeClassMapper/1.5.0
   https://www.nuget.org/packages/TypeClassMapper/1.4.0
   https://www.nuget.org/packages/TypeClassMapper/1.3.0

--- a/source/Cross-platform/TypeClassMapper/TypeClassMapper.csproj
+++ b/source/Cross-platform/TypeClassMapper/TypeClassMapper.csproj
@@ -2,16 +2,18 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.5.0</Version>
+    <Version>1.7.0</Version>
     <Authors>Marco A. Dorantes</Authors>
     <Description>TypeClassMapper is a basic .NET runtime dependency Type-Class mapping class - Given the runtime dependency management tradition of early design patterns, e.g., Microsoft COM IUnknown::QueryInterface method, this class follows such design tradition and relies on basic equivalent mechanisms from .NET Framework (System.IServiceProvider interface).</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MarcoDorantes/ioc</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MarcoDorantes/ioc</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
-    <Copyright>Copyright © Textum 2016. Marco A. Dorantes</Copyright>
+    <Copyright>Copyright © Textum 2021. Marco A. Dorantes</Copyright>
     <PackageTags>IoC Container Dependency Inversion</PackageTags>
-    <PackageReleaseNotes>As .NET Standard</PackageReleaseNotes>
+    <PackageReleaseNotes>Added net5.0 to existing test case runtimes (besides netcoreapp3.1).
+AddMapping method adds exception for the case of unsupported non-deterministic object mapping.
+Added ctor for Type_Class_Catalog with Client_Type type parameter is Type.</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/source/Cross-platform/TypeClassMapperSpec/TypeClassMapperSpec.csproj
+++ b/source/Cross-platform/TypeClassMapperSpec/TypeClassMapperSpec.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\NETCoreRuntime\TypeClassMapperSpec\LocalRuntimeConfigSpec.cs" Link="LocalRuntimeConfigSpec.cs" />
     <Compile Include="..\..\TypeClassMapperSpec\ImplicitMappingCases.cs" Link="ImplicitMappingCases.cs" />
     <Compile Include="..\..\TypeClassMapperSpec\ExplicitMappingCases.cs" Link="ExplicitMappingCases.cs" />
     <Compile Include="..\..\TypeClassMapperSpec\ImplicitMappingCasesAtNoDefaultSection.cs" Link="ImplicitMappingCasesAtNoDefaultSection.cs" />
@@ -18,13 +19,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TypeClassMapper\TypeClassMapper.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <None Update="..\..\TypeClassMapperSpec\App.config">
+      <Link>testhost.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <None Update="..\..\TypeClassMapperSpec\App.config">
+      <Link>testhost.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/source/NETCoreRuntime/TypeClassMapperSpec/LocalRuntimeConfigSpec.cs
+++ b/source/NETCoreRuntime/TypeClassMapperSpec/LocalRuntimeConfigSpec.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MsTestOnNetRuntime
+{
+    /// <summary>
+    /// Check the runtime effect of x64 option of menu Test/ProcessorArchitecture on System.Configuration.ConfigurationManager.
+    /// </summary>
+    [TestClass]
+    public class LocalRuntimeConfigSpec
+    {
+        [TestMethod, TestCategory("Runtime")]
+        public void CheckMenuOptionSelected_TEST_ProcessorArchitecture_x64()
+        {
+            Assert.IsNull(System.Configuration.ConfigurationManager.ConnectionStrings["NonExtant"]);
+            Assert.AreEqual(null, System.Configuration.ConfigurationManager.AppSettings["NonExtant"]);
+        }
+    }
+}

--- a/source/NETCoreRuntime/TypeClassMapperSpec/TypeClassMapperSpec.csproj
+++ b/source/NETCoreRuntime/TypeClassMapperSpec/TypeClassMapperSpec.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -18,13 +18,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Cross-platform\TypeClassMapper\TypeClassMapper.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <None Update="..\..\TypeClassMapperSpec\App.config">
+      <Link>testhost.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <None Update="..\..\TypeClassMapperSpec\App.config">
+      <Link>testhost.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/source/NETFrameworkRuntime/TypeClassMapperSpec/TypeClassMapperSpec.csproj
+++ b/source/NETFrameworkRuntime/TypeClassMapperSpec/TypeClassMapperSpec.csproj
@@ -57,10 +57,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.0.0</Version>
+      <Version>2.1.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.0.0</Version>
+      <Version>2.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/source/TypeClassMapper/DefaultClass/TypeClassMapper.cs
+++ b/source/TypeClassMapper/DefaultClass/TypeClassMapper.cs
@@ -14,7 +14,6 @@ namespace nutility
     /// <summary>
     /// Keep Type - Class catalog.
     /// </summary>
-//    private IList<Mapping> typeclass_catalog;
     private IList<Mapping<TypeClassID, TypeClassID>> typeclass_catalog;
 
     /// <summary>
@@ -125,10 +124,6 @@ namespace nutility
     /// <param name="Type_Object_Map">Type-Object map</param>
     public TypeClassMapper(IEnumerable<KeyValuePair<TypeClassID, object>> Type_Object_Map)
     {
-      if (Type_Object_Map == null)
-      {
-        throw new TypeClassMapperException($"Parameter cannot be null: {nameof(Type_Object_Map)}", new ArgumentNullException(nameof(Type_Object_Map)));
-      }
       this.scope = "<explicit>";
       this.section = "<explicit>";
 
@@ -144,10 +139,6 @@ namespace nutility
     /// <param name="Type_Object_Map">Type-Object map</param>
     public TypeClassMapper(IEnumerable<KeyValuePair<Type, object>> Type_Object_Map)
     {
-      if (Type_Object_Map == null)
-      {
-        throw new TypeClassMapperException($"Parameter cannot be null: {nameof(Type_Object_Map)}", new ArgumentNullException(nameof(Type_Object_Map)));
-      }
       this.scope = "<explicit>";
       this.section = "<explicit>";
 
@@ -308,14 +299,17 @@ namespace nutility
       InitializeNameObjectMap(null, new Dictionary<string, object>());
     }
 
-    /* TODO add first the test case
+    /// <summary>
+    /// For explicit type-class mappings.
+    /// </summary>
+    /// <param name="Type_Class_Catalog">RequiredType-ClientType-MappedClass catalog</param>
     public TypeClassMapper(IEnumerable<Mapping<TypeClassID, Type>> Type_Class_Catalog)
     {
-      InitializeTypeClassCatalog<Type, TypeClassID>(null, null, Type_Class_Catalog.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType, ClientType = next.ClientType?.FullName, MappedClass = next.MappedClass }); return whole; }));
+      InitializeTypeClassCatalog<Type, TypeClassID>(null, null, Type_Class_Catalog?.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType, ClientType = next.ClientType?.FullName, MappedClass = next.MappedClass }); return whole; }));
       InitializeTypeCreatorMap<Type>(null, null, new Dictionary<TypeClassID, Func<object>>());
       InitializeTypeObjectMap<TypeClassID>(null, null, new Dictionary<TypeClassID, object>());
       InitializeNameObjectMap(null, new Dictionary<string, object>());
-    }*/
+    }
 
     /// <summary>
     /// For explicit type-class mappings.
@@ -323,7 +317,7 @@ namespace nutility
     /// <param name="Type_Class_Catalog">RequiredType-ClientType-MappedClass catalog</param>
     public TypeClassMapper(IEnumerable<Mapping<Type, Type>> Type_Class_Catalog)
     {
-      InitializeTypeClassCatalog<Type, TypeClassID>(null, null, Type_Class_Catalog.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType.FullName, ClientType = next.ClientType?.FullName, MappedClass = next.MappedClass.AssemblyQualifiedName }); return whole; }));
+      InitializeTypeClassCatalog<Type, TypeClassID>(null, null, Type_Class_Catalog?.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType.FullName, ClientType = next.ClientType?.FullName, MappedClass = next.MappedClass.AssemblyQualifiedName }); return whole; }));
       InitializeTypeCreatorMap<Type>(null, null, new Dictionary<TypeClassID, Func<object>>());
       InitializeTypeObjectMap<TypeClassID>(null, null, new Dictionary<TypeClassID, object>());
       InitializeNameObjectMap(null, new Dictionary<string, object>());
@@ -335,7 +329,7 @@ namespace nutility
     /// <param name="Type_Class_Catalog">RequiredType-ClientType-MappedClass catalog</param>
     public TypeClassMapper(IEnumerable<Mapping<Type, TypeClassID>> Type_Class_Catalog)
     {
-      InitializeTypeClassCatalog<Type, TypeClassID>(null, null, Type_Class_Catalog.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType.FullName, ClientType = next.ClientType, MappedClass = next.MappedClass.AssemblyQualifiedName }); return whole; }));
+      InitializeTypeClassCatalog<Type, TypeClassID>(null, null, Type_Class_Catalog?.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType.FullName, ClientType = next.ClientType, MappedClass = next.MappedClass.AssemblyQualifiedName }); return whole; }));
       InitializeTypeCreatorMap<Type>(null, null, new Dictionary<TypeClassID, Func<object>>());
       InitializeTypeObjectMap<TypeClassID>(null, null, new Dictionary<TypeClassID, object>());
       InitializeNameObjectMap(null, new Dictionary<string, object>());
@@ -348,9 +342,8 @@ namespace nutility
     /// <param name="Type_Class_Catalog_part2">Second part of the RequiredType-ClientType-MappedClass catalog</param>
     public TypeClassMapper(IEnumerable<Mapping<Type, TypeClassID>> Type_Class_Catalog_part1, IEnumerable<Mapping<Type, Type>> Type_Class_Catalog_part2)
     {
-      //TODO: same input validation to all others
-      if (Type_Class_Catalog_part1 == null) { throw new ArgumentNullException(nameof(Type_Class_Catalog_part1)); }
-      if (Type_Class_Catalog_part2 == null) { throw new ArgumentNullException(nameof(Type_Class_Catalog_part2)); }
+      if (Type_Class_Catalog_part1 == null) throw new ArgumentNullException(nameof(Type_Class_Catalog_part1));
+      if (Type_Class_Catalog_part2 == null) throw new ArgumentNullException(nameof(Type_Class_Catalog_part2));
 
       var merged = Type_Class_Catalog_part1.Aggregate(new List<Mapping<TypeClassID, TypeClassID>>(), (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType.FullName, ClientType = next.ClientType, MappedClass = next.MappedClass.AssemblyQualifiedName }); return whole; });
       Type_Class_Catalog_part2.Aggregate(merged, (whole, next) => { whole.Add(new Mapping<TypeClassID, TypeClassID> { RequiredType = next.RequiredType.FullName, ClientType = next.ClientType?.FullName, MappedClass = next.MappedClass.AssemblyQualifiedName }); return whole; });
@@ -531,7 +524,7 @@ namespace nutility
         this.typeclass_catalog.Add(mapping);
         return;
       }
-      this.typeobjectmap.Add(typeof(T).FullName, value);
+      AddToObjectMap<T>(value);
     }
 
     /// <summary>
@@ -730,6 +723,23 @@ namespace nutility
         }
         this.nameobjectmap = Name_Object_Map.Aggregate(new Dictionary<string, object>(), (whole, next) => { whole.Add(next.Key, next.Value); return whole; });
       }
+    }
+
+    private void AddToObjectMap<T>(T value)
+    {
+      var typename = typeof(T).FullName;
+      if (typeobjectmap.ContainsKey(typename))
+      {
+        var instance = typeobjectmap[typename];
+        if (Object.ReferenceEquals(instance, value))
+        {
+          return;
+        }
+        throw new TypeClassMapperException($"Unsupported non-deterministic object mapping ({instancetype(instance)}, {instancetype(value)}) for {typename}.");
+      }
+      typeobjectmap.Add(typename, value);
+
+      string instancetype(object x) => x == null ? "<null>" : $"{x}:{x.GetType().FullName}";
     }
   }
 }

--- a/source/TypeClassMapperSpec/ExplicitMappingCases.cs
+++ b/source/TypeClassMapperSpec/ExplicitMappingCases.cs
@@ -329,6 +329,79 @@ namespace TypeClassMapperSpec
     }
 
     [TestMethod]
+    public void AddMappingDuplicatedNull()
+    {
+      //Arrange
+      var typemap = new nutility.TypeClassMapper(new Dictionary<Type, object> { { typeof(app1.ISource), null } });
+
+      //Act
+      typemap.AddMapping<app1.ISource>(null);
+      var source = (app1.ISource)typemap.GetService(typeof(app1.ISource));
+
+      //Assert
+      Assert.IsNull(source);
+    }
+
+    [TestMethod]
+    public void AddMappingDuplicatedSame()
+    {
+      //Arrange
+      var single_source = new module1.Source();
+      var typemap = new nutility.TypeClassMapper(new Dictionary<Type, object> { { typeof(app1.ISource), single_source } });
+      var same_source = single_source;
+
+      //Act
+      typemap.AddMapping<app1.ISource>(same_source);
+      var source = (app1.ISource)typemap.GetService(typeof(app1.ISource));
+
+      //Assert
+      Assert.IsNotNull(source);
+      Assert.AreSame(source, single_source);
+      Assert.AreSame(source, same_source);
+    }
+
+    [TestMethod]
+    public void AddMappingDuplicatedUnsupported()
+    {
+      //Arrange
+      var single_source = new module1.Source();
+      var other_source = new module1.Source();
+      var typemap = new nutility.TypeClassMapper(new Dictionary<Type, object> { { typeof(app1.ISource), single_source } });
+      nutility.TypeClassMapperException expected_exception = null;
+
+      //Act
+      try
+      {
+        typemap.AddMapping<app1.ISource>(other_source);
+      }
+      catch (nutility.TypeClassMapperException ex) { expected_exception = ex; }
+
+      //Assert
+      Assert.IsNotNull(expected_exception);
+      Assert.AreEqual("Unsupported non-deterministic object mapping (module1.Source:module1.Source, module1.Source:module1.Source) for app1.ISource.", expected_exception.Message);
+    }
+
+    [TestMethod]
+    public void AddMappingDuplicatedUnsupported2()
+    {
+      //Arrange
+      var single_source = new module1.Source();
+      var typemap = new nutility.TypeClassMapper(new Dictionary<Type, object> { { typeof(app1.ISource), single_source } });
+      nutility.TypeClassMapperException expected_exception = null;
+
+      //Act
+      try
+      {
+        typemap.AddMapping<app1.ISource>(null);
+      }
+      catch (nutility.TypeClassMapperException ex) { expected_exception = ex; }
+
+      //Assert
+      Assert.IsNotNull(expected_exception);
+      Assert.AreEqual("Unsupported non-deterministic object mapping (module1.Source:module1.Source, <null>) for app1.ISource.", expected_exception.Message);
+    }
+
+    [TestMethod]
     public void BadNullClassName2()
     {
       //Arrange
@@ -722,6 +795,28 @@ namespace TypeClassMapperSpec
       Assert.AreEqual<string>("nutility.TypeClassMapper", source1.Name);
       Assert.AreEqual<string>("module4.Order", order.Name);
       Assert.AreEqual<string>("module4.Target", target.Name);
+    }
+
+    [TestMethod]
+    public void TheTypeForMyCase6()
+    {
+      //Arrange
+      var typemap = new nutility.TypeClassMapper
+      (
+        new List<nutility.Mapping<nutility.TypeClassID, Type>>
+        {
+          new nutility.Mapping<nutility.TypeClassID, Type> { RequiredType = "app1.ISource", ClientType = typeof(module3.Source1), MappedClass = "module3.Source1, TypeClassMapperSpec" },
+          new nutility.Mapping<nutility.TypeClassID, Type> { RequiredType = "app1.ISource", ClientType = typeof(module1.Source), MappedClass = "module1.Source, TypeClassMapperSpec" }
+        }
+      );
+
+      //Act
+      app1.ISource source1 = typemap.GetService<app1.ISource>(Client_Type: typeof(module3.Source1));
+      app1.ISource source2 = typemap.GetService<app1.ISource>(Client_Type: typeof(module1.Source));
+
+      //Assert
+      Assert.AreEqual<string>("nutility.TypeClassMapper", source1.Name);
+      Assert.AreEqual<string>("module1.Source", source2.Name);
     }
 
     [TestMethod]

--- a/source/Windows/TypeClassMapper/Properties/AssemblyInfo.cs
+++ b/source/Windows/TypeClassMapper/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Textum - Marco A. Dorantes")]
 [assembly: AssemblyProduct("TypeClassMapper")]
-[assembly: AssemblyCopyright("Copyright © Textum 2016. Marco A. Dorantes")]
+[assembly: AssemblyCopyright("Copyright © Textum 2021. Marco A. Dorantes")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.7.0.0")]

--- a/source/Windows/TypeClassMapperSpec/TypeClassMapperSpec.csproj
+++ b/source/Windows/TypeClassMapperSpec/TypeClassMapperSpec.csproj
@@ -57,10 +57,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.0.0</Version>
+      <Version>2.1.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.0.0</Version>
+      <Version>2.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Released at https://www.nuget.org/packages/TypeClassMapper/1.7.0
Added net5.0 to existing test case runtimes (besides netcoreapp3.1).
AddMapping method adds exception for the case of unsupported non-deterministic object mapping.
Added ctor for Type_Class_Catalog with Client_Type type parameter is Type.
